### PR TITLE
support go work, refine document save and RootPackage resolve

### DIFF
--- a/src/group.ts
+++ b/src/group.ts
@@ -1,5 +1,5 @@
 import { Range, window, workspace, WorkspaceEdit, Position } from 'vscode'
-import { resolveRootPackage, getImportsRange, getImports } from './utils'
+import { resolveRootPackage, getImportsRange, getImports, execCommand } from './utils'
 import { getIncludeOrgGroupSettings } from './register'
 
 export const goGroupImports = async () => {
@@ -20,11 +20,15 @@ export const goGroupImports = async () => {
   }
   // TODO show error
 
+  const projectRoot = workspace.workspaceFolders[0].uri.path;
+  const output = await execCommand(projectRoot, 'go list -m');
+  const modules = output.split('\n').filter(line => line.trim() !== '');
+
   const imports = getImports(documentText)
 
   if (!imports.length) return
 
-  const groupedList = group(imports, rootPkg, getIncludeOrgGroupSettings())
+  const groupedList = group(imports, rootPkg, modules, getIncludeOrgGroupSettings())
 
   const importsRange = getImportsRange(documentText)
 
@@ -44,6 +48,7 @@ type ImportGroups = {
   stdlib: string[]
   thirdParty: string[]
   organization: string[]
+  workspace: string[]
   own: string[]
 }
 
@@ -55,21 +60,27 @@ const isImportFrom = (imp: string, root: string): boolean => {
   return imp.includes(root)
 }
 
+
 export const group = (
   imports: string[],
-  rootPkg,
+  rootPkg: string,
+  workspacePkgs: string[],
   organizationPkg: string
 ): ImportGroups => {
   const importGroups = <ImportGroups>{
     stdlib: [],
     thirdParty: [],
     organization: [],
+    workspace: [],
     own: [],
   }
 
+  workspacePkgs = workspacePkgs.filter(pkg => pkg !== rootPkg);
   imports.forEach((imp) => {
     if (isImportFrom(imp, rootPkg)) {
       importGroups.own.push(imp)
+    } else if (workspacePkgs.some(pkg => isImportFrom(imp, pkg))) {
+      importGroups.workspace.push(imp)
     } else if (isStdlibImport(imp)) {
       importGroups.stdlib.push(imp)
     } else if (organizationPkg != '' && isImportFrom(imp, organizationPkg)) {

--- a/src/groupOnSave.ts
+++ b/src/groupOnSave.ts
@@ -1,9 +1,0 @@
-import { window } from 'vscode';
-import { goGroupImports } from './group';
-
-export const groupImportsOnSave = () => {
-  if (!window.activeTextEditor.document.languageId.includes('go')) {
-    return;
-  }
-  return goGroupImports();
-};

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,6 +1,5 @@
-import { Disposable, workspace } from 'vscode'
-
-import { groupImportsOnSave } from './groupOnSave'
+import { Disposable, workspace, TextDocumentWillSaveEvent } from 'vscode'
+import { goGroupImports } from './group';
 
 let saveRegistration: Disposable
 
@@ -18,7 +17,13 @@ const registerWillSaveTextDocument = () => {
     return
   }
 
-  saveRegistration = workspace.onWillSaveTextDocument(groupImportsOnSave)
+  saveRegistration = workspace.onWillSaveTextDocument(async (e: TextDocumentWillSaveEvent) => {
+    const document = e.document;
+    if (document.languageId === 'go') {
+      const edits = goGroupImports()
+      e.waitUntil(edits);
+    }
+  })
 }
 
 export const getOnSaveSetting = () => {

--- a/src/test/group.test.ts
+++ b/src/test/group.test.ts
@@ -4,6 +4,10 @@ import { group } from '../group';
 
 const ROOT = 'github.com/blackdahila';
 const ORGANIZATION = 'github.com/organization';
+const WORKSPACE = [
+  'util',
+  'xxx',
+];
 
 suite('Group Test', () => {
   test('should return the same list if all imports are from the same group', () => {
@@ -12,7 +16,7 @@ suite('Group Test', () => {
       'math',
       'errors',
     ];
-    const groupedImports = group(imports, ROOT, ORGANIZATION);
+    const groupedImports = group(imports, ROOT, WORKSPACE, ORGANIZATION);
 
     assert.deepEqual(groupedImports.stdlib, imports);
     assert.deepEqual(groupedImports.own, []);
@@ -21,7 +25,7 @@ suite('Group Test', () => {
 
   test('should return group imports for two different groups', () => {
     const imports = ['fmt', 'math', 'errors', 'github.com/package/package'];
-    const groupedImports = group(imports, ROOT, ORGANIZATION);
+    const groupedImports = group(imports, ROOT, WORKSPACE, ORGANIZATION);
 
     assert.deepEqual(groupedImports.stdlib, imports.slice(0, 3));
     assert.deepEqual(groupedImports.thirdParty, imports.slice(3));
@@ -30,7 +34,7 @@ suite('Group Test', () => {
 
   test('should return separated third party imports from own imports', () => {
     const imports = ['github.com/blackdahila/package', 'github.com/package/package'];
-    const groupedImports = group(imports, ROOT, ORGANIZATION);
+    const groupedImports = group(imports, ROOT, WORKSPACE, ORGANIZATION);
 
     assert.deepEqual(groupedImports.thirdParty, [imports[1]]);
     assert.deepEqual(groupedImports.own, [imports[0]]);
@@ -48,7 +52,7 @@ suite('Group Test', () => {
       'github.com/jmoiron/sqlx',
       'test "github.com/blackdahila/testing"',
     ];
-    const groupedImports = group(imports, ROOT, ORGANIZATION);
+    const groupedImports = group(imports, ROOT, WORKSPACE, ORGANIZATION);
 
     assert.deepEqual(groupedImports.thirdParty, [
       'github.com/package/package',
@@ -80,7 +84,7 @@ suite('Group Test', () => {
       'test "github.com/blackdahila/testing"',
       'github.com/organization/aa',
     ];
-    const groupedImports = group(imports, ROOT, ORGANIZATION);
+    const groupedImports = group(imports, ROOT, WORKSPACE, ORGANIZATION);
 
     assert.deepEqual(groupedImports.thirdParty, [
       'github.com/package/package',
@@ -100,6 +104,49 @@ suite('Group Test', () => {
       'c github.com/organization/cc',
       'github.com/organization/foo',
       'github.com/organization/aa',
+    ]);
+  });
+
+  test('should return grouped mixed imports with workspace', () => {
+    const imports = [
+      'github.com/blackdahila/package',
+      'github.com/package/package',
+      'math',
+      'fmt',
+      'c github.com/organization/cc',
+      'err "errors"',
+      'database/sql',
+      'github.com/jmoiron/sqlx',
+      'util/foo',
+      'github.com/organization/foo',
+      'test "github.com/blackdahila/testing"',
+      'xxx/foo',
+      'github.com/organization/aa',
+    ];
+    const groupedImports = group(imports, ROOT, WORKSPACE, ORGANIZATION);
+
+    assert.deepEqual(groupedImports.thirdParty, [
+      'github.com/package/package',
+      'github.com/jmoiron/sqlx',
+    ]);
+    assert.deepEqual(groupedImports.own, [
+      'github.com/blackdahila/package',
+      'test "github.com/blackdahila/testing"',
+    ]);
+    assert.deepEqual(groupedImports.organization, [
+      'c github.com/organization/cc',
+      'github.com/organization/foo',
+      'github.com/organization/aa',
+    ]);
+    assert.deepEqual(groupedImports.workspace, [
+      'util/foo',
+      'xxx/foo',
+    ]);
+    assert.deepEqual(groupedImports.stdlib, [
+      'math',
+      'fmt',
+      'err "errors"',
+      'database/sql',
     ]);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { window } from 'vscode';
 const { readdir, readFile } = require('fs').promises;
+import { exec } from 'child_process';
 
 export const multilineImportsGroupRegex = /import \(([^)]+)\)/;
 export const moduleRegex = /module (.*?)\n/;
@@ -109,4 +110,19 @@ export const getImportsRange = (documentText: string): ImportsRange => {
     end,
     start,
   };
+};
+
+
+export const execCommand = (workspacePath: string, command: string): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    exec(command, { cwd: workspacePath }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`Error executing command: ${error.message}`));
+      } else if (stderr) {
+        reject(new Error(`Stderr output: ${stderr}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
 };


### PR DESCRIPTION
I add a new group that collects all other module imports in the same workspace (go work). Additionally, I met some document saving issues and unexpect group result when my project is in GOPATH but using gomod. I make it use go mod first if GO111MODULE=on.